### PR TITLE
Fix front-end pet API response handling

### DIFF
--- a/client/src/pages/Browse.js
+++ b/client/src/pages/Browse.js
@@ -54,8 +54,9 @@ const Browse = () => {
       console.log('🔍 Fetching pets with params:', params);
       const response = await petAPI.getAllPets(params);
       console.log('🐾 Browse pets response:', response);
-      
-      setPets(response.data || []);
+
+      // API returns { success: true, data: [...] }
+      setPets(response.data?.data || []);
     } catch (err) {
       console.error('Error fetching pets:', err);
       setError('Failed to load pets. Please try again.');

--- a/client/src/pages/SearchResults.js
+++ b/client/src/pages/SearchResults.js
@@ -27,7 +27,8 @@ const SearchResults = () => {
         if (category) params.category = category;
 
         const response = await petAPI.getAllPets(params);
-        setResults(response.pets || []);
+        // API returns { success: true, data: [...] }
+        setResults(response.data?.data || []);
       } catch (err) {
         setError("Failed to fetch search results");
       } finally {

--- a/client/src/pages/SmallPets.js
+++ b/client/src/pages/SmallPets.js
@@ -13,7 +13,8 @@ const SmallPets = () => {
     const fetchSmallPets = async () => {
       try {
         const response = await petAPI.getAllPets({ category: "small-pets" });
-        setSmallPets(response.pets || []);
+        // API returns { success: true, data: [...] }
+        setSmallPets(response.data?.data || []);
       } catch (err) {
         setError("Failed to load small pets");
       } finally {


### PR DESCRIPTION
## Summary
- fix browse page to handle API object response
- update search results and small pets pages to use `response.data.data`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68712524e934832b96b196b953d864f7