### PR TITLE
Fix login JSON parse error handling

### DIFF
--- a/client/src/contexts/AuthContext.js
+++ b/client/src/contexts/AuthContext.js
@@ -122,7 +122,14 @@ export const AuthProvider = ({ children }) => {
       // ✅ IMPROVED: Better error handling for non-JSON responses
       let data;
       try {
-        data = await response.json();
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+          data = await response.json();
+        } else {
+          const text = await response.text();
+          console.error('Expected JSON, received:', text);
+          throw new Error('Invalid JSON response');
+        }
       } catch (jsonError) {
         console.error('Failed to parse JSON response:', jsonError);
         console.error('Response status:', response.status);


### PR DESCRIPTION
## Summary
- improve login JSON response error handling

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68715dd2c738832bbb312d82bb3be7b4