### PR TITLE
Add news API service functions and convert to CommonJS

### DIFF
--- a/server/routes/news.js
+++ b/server/routes/news.js
@@ -2,9 +2,13 @@
 const express = require('express');
 const router = express.Router();
 const crypto = require('crypto');
-const axios = require('axios');
 const NewsArticle = require('../models/NewsArticle'); // ✅ Use your existing model
 const { protect, admin } = require('../middleware/auth');
+const {
+  fetchPetNews,
+  getFallbackNews,
+  getNewsServiceHealth,
+} = require('../services/newsAPI');
 
 // ===== HELPER FUNCTIONS =====
 
@@ -34,83 +38,6 @@ const formatExternal = (article) => ({
   type: 'external'
 });
 
-// ✅ Fetch external news directly (replaces broken service)
-const fetchExternalNews = async (query = 'pets OR dogs OR cats', limit = 10) => {
-  try {
-    const NEWS_API_KEY = process.env.NEWS_API_KEY;
-    
-    if (!NEWS_API_KEY) {
-      console.log('⚠️ No NewsAPI key configured - using fallback');
-      return getFallbackExternalNews();
-    }
-
-    const response = await axios.get('https://newsapi.org/v2/everything', {
-      params: {
-        q: query,
-        language: 'en',
-        sortBy: 'publishedAt',
-        pageSize: limit,
-        apiKey: NEWS_API_KEY
-      },
-      timeout: 10000
-    });
-
-    return {
-      success: true,
-      articles: response.data.articles || [],
-      source: 'newsapi'
-    };
-  } catch (error) {
-    console.error('❌ External news fetch error:', error.message);
-    return getFallbackExternalNews();
-  }
-};
-
-// ✅ Fallback news data
-const getFallbackExternalNews = () => {
-  return {
-    success: true,
-    articles: [
-      {
-        title: 'Pet Adoption Tips for New Families',
-        description: 'Essential guide for families considering pet adoption this season.',
-        content: 'When adopting a pet, preparation is key...',
-        url: 'https://example.com/adoption-tips',
-        urlToImage: 'https://images.unsplash.com/photo-1601758228041-f3b2795255f1?w=400',
-        publishedAt: new Date().toISOString(),
-        source: { name: 'Pet Care Guide' },
-        author: 'Pet Expert'
-      },
-      {
-        title: 'Senior Pet Care: What You Need to Know',
-        description: 'Special considerations for caring for older pets in your home.',
-        content: 'Senior pets require extra attention and care...',
-        url: 'https://example.com/senior-pet-care',
-        urlToImage: 'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?w=400',
-        publishedAt: new Date().toISOString(),
-        source: { name: 'Pet Health Today' },
-        author: 'Dr. Pet Care'
-      }
-    ],
-    isFallback: true,
-    source: 'fallback'
-  };
-};
-
-// ✅ Health check for news service
-const getNewsServiceHealth = () => {
-  return {
-    status: 'operational',
-    timestamp: new Date().toISOString(),
-    services: {
-      database: 'connected',
-      externalAPI: {
-        configured: !!process.env.NEWS_API_KEY,
-        status: process.env.NEWS_API_KEY ? 'operational' : 'fallback'
-      }
-    }
-  };
-};
 
 // ===== MAIN ROUTES =====
 
@@ -184,7 +111,7 @@ router.get('/', async (req, res) => {
     // ✅ Include external articles if requested
     if (source === 'all' || source === 'external') {
       const searchQuery = search || 'pets OR dogs OR cats OR pet adoption';
-      const externalResult = await fetchExternalNews(searchQuery, 10);
+      const externalResult = await fetchPetNews(searchQuery, 10);
       
       if (externalResult.success && externalResult.articles) {
         const formattedExternal = externalResult.articles.map(formatExternal);
@@ -242,7 +169,7 @@ router.get('/featured', async (req, res) => {
     // ✅ Fill remaining slots with external news if needed
     const remaining = parseInt(limit) - featuredCustom.length;
     if (remaining > 0) {
-      const externalResult = await fetchExternalNews('pets trending news', remaining);
+      const externalResult = await fetchPetNews('pets trending news', remaining);
       
       if (externalResult.success && externalResult.articles) {
         const formattedExternal = externalResult.articles
@@ -271,7 +198,7 @@ router.get('/featured', async (req, res) => {
     console.error('❌ GET /news/featured error:', err);
     
     // ✅ Return fallback data instead of failure
-    const fallbackData = getFallbackExternalNews();
+    const fallbackData = getFallbackNews();
     res.json({
       success: true,
       data: fallbackData.articles.map(formatExternal).slice(0, parseInt(req.query.limit || 6)),
@@ -336,7 +263,7 @@ router.get('/external', async (req, res) => {
   try {
     const { search = 'pets OR dogs OR cats', limit = 20 } = req.query;
     
-    const externalResult = await fetchExternalNews(search, parseInt(limit));
+    const externalResult = await fetchPetNews(search, parseInt(limit));
     
     if (externalResult.success && externalResult.articles) {
       const formattedArticles = externalResult.articles.map(formatExternal);

--- a/server/services/newsAPI.js
+++ b/server/services/newsAPI.js
@@ -1,51 +1,105 @@
-// client/src/services/newsAPI.js - Uses backend-proxy, no frontend API keys
-import axios from 'axios';
+// server/services/newsAPI.js
+// Helper functions for fetching pet-related news from external sources
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://furbabies-backend.onrender.com/api';
+const axios = require('axios');
 
-export const newsAPI = {
-  // Get featured (custom + external) articles
-  getFeaturedNews: (limit = 6) => {
-    return axios.get(`${API_BASE_URL}/news/featured?limit=${limit}`);
-  },
+const NEWS_API_URL = 'https://newsapi.org/v2/everything';
+const DEFAULT_QUERY = 'pets OR dogs OR cats';
 
-  // Get all articles (with filters)
-  getAllNews: (params = {}) => {
-    const query = new URLSearchParams(params).toString();
-    return axios.get(`${API_BASE_URL}/news?${query}`);
-  },
+// Fetch pet news with optional query and limit
+const fetchPetNews = async (query = DEFAULT_QUERY, limit = 10) => {
+  try {
+    const apiKey = process.env.NEWS_API_KEY;
+    if (!apiKey) {
+      console.log('⚠️ No NewsAPI key configured - using fallback');
+      return getFallbackNews();
+    }
 
-  // Get a specific article by ID
-  getArticleById: (id) => {
-    return axios.get(`${API_BASE_URL}/news/${id}`);
-  },
+    const response = await axios.get(NEWS_API_URL, {
+      params: {
+        q: query,
+        language: 'en',
+        sortBy: 'publishedAt',
+        pageSize: limit,
+        apiKey,
+      },
+      timeout: 10000,
+    });
 
-  // Like an article
-  likeArticle: (id) => {
-    return axios.post(`${API_BASE_URL}/news/${id}/like`);
-  },
-
-  // Get only internal (admin-created) articles
-  getCustomArticles: (params = {}) => {
-    const query = new URLSearchParams(params).toString();
-    return axios.get(`${API_BASE_URL}/news/custom?${query}`);
-  },
-
-  // Get only external (NewsAPI.org) articles
-  getExternalArticles: (params = {}) => {
-    const query = new URLSearchParams(params).toString();
-    return axios.get(`${API_BASE_URL}/news/external?${query}`);
-  },
-
-  // Get category breakdown (for filters or UI)
-  getCategories: () => {
-    return axios.get(`${API_BASE_URL}/news/categories`);
-  },
-
-  // Health check for news service
-  getHealth: () => {
-    return axios.get(`${API_BASE_URL}/news/health`);
+    return {
+      success: true,
+      articles: response.data.articles || [],
+      source: 'newsapi',
+    };
+  } catch (error) {
+    console.error('❌ External news fetch error:', error.message);
+    return getFallbackNews();
   }
+};
+
+// Search news by a specific topic
+const searchPetNewsByTopic = (topic, limit = 10) => {
+  const query = topic
+    ? `${topic} AND (pets OR dogs OR cats OR pet adoption)`
+    : DEFAULT_QUERY;
+  return fetchPetNews(query, limit);
+};
+
+// Get trending pet news
+const getTrendingPetNews = (limit = 10) => {
+  return fetchPetNews('pets trending OR pet adoption', limit);
+};
+
+// Verify that the NewsAPI service is reachable
+const testNewsAPIConnection = async () => {
+  const result = await fetchPetNews(DEFAULT_QUERY, 1);
+  return result.success && Array.isArray(result.articles);
+};
+
+// Fallback news content in case the external API is unavailable
+const getFallbackNews = () => {
+  return {
+    success: true,
+    articles: [
+      {
+        title: 'Pet Adoption Tips for New Families',
+        description: 'Essential guide for families considering pet adoption this season.',
+        content: 'When adopting a pet, preparation is key...',
+        url: 'https://example.com/adoption-tips',
+        urlToImage: 'https://images.unsplash.com/photo-1601758228041-f3b2795255f1?w=400',
+        publishedAt: new Date().toISOString(),
+        source: { name: 'Pet Care Guide' },
+        author: 'Pet Expert',
+      },
+      {
+        title: 'Senior Pet Care: What You Need to Know',
+        description: 'Special considerations for caring for older pets in your home.',
+        content: 'Senior pets require extra attention and care...',
+        url: 'https://example.com/senior-pet-care',
+        urlToImage:
+          'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?w=400',
+        publishedAt: new Date().toISOString(),
+        source: { name: 'Pet Health Today' },
+        author: 'Dr. Pet Care',
+      },
+    ],
+    isFallback: true,
+    source: 'fallback',
+  };
+};
+
+// Health check information for the news service
+const getNewsServiceHealth = () => {
+  return {
+    status: 'operational',
+    timestamp: new Date().toISOString(),
+    services: {
+      externalAPI: {
+        configured: !!process.env.NEWS_API_KEY,
+        status: process.env.NEWS_API_KEY ? 'operational' : 'fallback',
+      },
+    },
+  };
 };
 
 module.exports = {
@@ -54,5 +108,6 @@ module.exports = {
   getTrendingPetNews,
   testNewsAPIConnection,
   getFallbackNews,
-  getNewsServiceHealth
+  getNewsServiceHealth,
 };
+


### PR DESCRIPTION
## Summary
- implement news API helper functions using CommonJS in server/services/newsAPI.js
- update news routes to use new service and remove inline axios logic

## Testing
- `npm test`
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899259adc94832ba6238029e7fbfe11