### PR TITLE
Use String.repeat for separators in test news script

### DIFF
--- a/server/services/test-news.js
+++ b/server/services/test-news.js
@@ -67,7 +67,7 @@ async function testEndpoint(name, url, expectedFields = []) {
 
 async function runAllTests() {
   log('\n🚀 Starting News Functionality Tests', 'cyan');
-  log('=' * 50, 'cyan');
+  log('='.repeat(50), 'cyan');
   
   const results = {
     passed: 0,
@@ -236,7 +236,7 @@ async function runAllTests() {
 
   // Final Results
   log('\n📊 Test Results Summary', 'cyan');
-  log('=' * 30, 'cyan');
+  log('='.repeat(30), 'cyan');
   logSuccess(`Passed: ${results.passed}`);
   if (results.warnings > 0) {
     logWarning(`Warnings: ${results.warnings}`);


### PR DESCRIPTION
## Summary
- Replace Python-style `'=' * 50` and `'=' * 30` with JavaScript `"=".repeat(50)` and `"=".repeat(30)` in test news script

## Testing
- `node server/services/test-news.js`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6899259de968832bad6b4729a345b3dc