### PR TITLE
Switch server controllers to CommonJS modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,10 @@ coverage.*
 *.test.js
 jest-html-reporters-*.html
 
+# Allow controller smoke tests
+!server/controllers/__tests__/
+!server/controllers/__tests__/controllers.test.js
+
 # =============================================================================
 # OS / EDITOR FILES
 # =============================================================================

--- a/server/controllers/__tests__/controllers.test.js
+++ b/server/controllers/__tests__/controllers.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+
+// Contact controller
+const contactController = require('../contactController');
+assert.strictEqual(typeof contactController.submitContact, 'function', 'submitContact should be a function');
+assert.strictEqual(typeof contactController.getAllContacts, 'function', 'getAllContacts should be a function');
+
+// Pet controller
+const petController = require('../petController');
+assert.strictEqual(typeof petController.getAllPets, 'function', 'getAllPets should be a function');
+assert.strictEqual(typeof petController.getPetById, 'function', 'getPetById should be a function');
+
+// User controller
+const userController = require('../userController');
+assert.strictEqual(typeof userController.register, 'function', 'register should be a function');
+assert.strictEqual(typeof userController.login, 'function', 'login should be a function');
+
+console.log('Controller smoke tests passed');

--- a/server/controllers/contactController.js
+++ b/server/controllers/contactController.js
@@ -1,8 +1,8 @@
 // ===== server/controllers/contactController.js =====
-import Contact from '../models/Contact.js';
+const Contact = require('../models/Contact');
 
 // Submit contact form
-export const submitContact = async (req, res) => {
+const submitContact = async (req, res) => {
   try {
     const { name, email, subject, message } = req.body;
     
@@ -36,7 +36,7 @@ export const submitContact = async (req, res) => {
 };
 
 // Get all contacts (admin only)
-export const getAllContacts = async (req, res) => {
+const getAllContacts = async (req, res) => {
   try {
     const { status, page = 1, limit = 10 } = req.query;
     
@@ -71,10 +71,7 @@ export const getAllContacts = async (req, res) => {
   }
 };
 
-// Default export with all functions
-const contactController = {
+module.exports = {
   submitContact,
   getAllContacts
 };
-
-export default contactController;

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -18,4 +18,4 @@ const petController = {
   }
 };
 
-export default petController;
+module.exports = petController;

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,7 +1,7 @@
 // server/controllers/userController.js
-import User from '../models/User.js';
-import Pet from '../models/Pet.js';
-import jwt from 'jsonwebtoken';
+const User = require('../models/User');
+const Pet = require('../models/Pet');
+const jwt = require('jsonwebtoken');
 
 // Generate JWT token
 const generateToken = (userId) => {
@@ -11,7 +11,7 @@ const generateToken = (userId) => {
 };
 
 // Register user
-export const register = async (req, res) => {
+const register = async (req, res) => {
   try {
     const { username, email, password, firstName, lastName } = req.body;
     
@@ -67,7 +67,7 @@ export const register = async (req, res) => {
 };
 
 // Login user
-export const login = async (req, res) => {
+const login = async (req, res) => {
   try {
     const { email, password } = req.body;
     
@@ -116,7 +116,7 @@ export const login = async (req, res) => {
 };
 
 // Get user profile
-export const getProfile = async (req, res) => {
+const getProfile = async (req, res) => {
   try {
     const user = await User.findById(req.user.id)
       .select('-password')
@@ -136,7 +136,7 @@ export const getProfile = async (req, res) => {
 };
 
 // Update user profile
-export const updateProfile = async (req, res) => {
+const updateProfile = async (req, res) => {
   try {
     const updates = req.body;
     
@@ -166,7 +166,7 @@ export const updateProfile = async (req, res) => {
 };
 
 // Get user favorites
-export const getFavorites = async (req, res) => {
+const getFavorites = async (req, res) => {
   try {
     const user = await User.findById(req.user.id)
       .populate('favoritesPets')
@@ -186,7 +186,7 @@ export const getFavorites = async (req, res) => {
 };
 
 // Add pet to favorites
-export const addToFavorites = async (req, res) => {
+const addToFavorites = async (req, res) => {
   try {
     const petId = req.params.petId;
     const userId = req.user.id;
@@ -221,7 +221,7 @@ export const addToFavorites = async (req, res) => {
 };
 
 // Remove pet from favorites
-export const removeFromFavorites = async (req, res) => {
+const removeFromFavorites = async (req, res) => {
   try {
     const petId = req.params.petId;
     const userId = req.user.id;
@@ -245,8 +245,8 @@ export const removeFromFavorites = async (req, res) => {
   }
 };
 
-// Default export
-const userController = {
+// Export controller functions
+module.exports = {
   register,
   login,
   getProfile,
@@ -255,5 +255,3 @@ const userController = {
   addToFavorites,
   removeFromFavorites
 };
-
-export default userController;

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "echo \"No tests configured yet\""
+    "test": "node controllers/__tests__/controllers.test.js"
   },
   "keywords": [
     "pet",


### PR DESCRIPTION
## Summary
- refactor contact, pet, and user controllers to use `require`/`module.exports` syntax for compatibility with the CommonJS server setup.

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689968c057cc832baa66388db908b6b8