### PR TITLE
Require API URL env variable for production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ JWT_SECRET=your_secret
 NODE_ENV=development
 PORT=5000
 FRONTEND_URL=http://localhost:3000
+REACT_APP_API_URL=http://localhost:5000/api
 SMTP_HOST=your_smtp_host
 SMTP_PORT=587
 SMTP_USER=your_smtp_username
@@ -173,6 +174,7 @@ furbabies-petstore/
 | NODE_ENV        | Environment              | ✅       |
 | PORT            | Backend server port      | ✅       |
 | FRONTEND_URL    | CORS origin              | ✅       |
+| REACT_APP_API_URL | Base URL for frontend API requests | ✅ (prod) |
 | SMTP_HOST       | SMTP server hostname     | ✅       |
 | SMTP_PORT       | SMTP server port         | ✅       |
 | SMTP_USER       | SMTP username            | ✅       |

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -3,17 +3,15 @@ import axios from 'axios';
 
 // ✅ Environment-based API URL configuration
 const getBaseURL = () => {
-  if (process.env.REACT_APP_API_URL) {
+  if (process.env.NODE_ENV === 'production') {
+    if (!process.env.REACT_APP_API_URL) {
+      throw new Error('REACT_APP_API_URL is required in production');
+    }
     return process.env.REACT_APP_API_URL;
   }
-  
-  // Production detection
-  if (process.env.NODE_ENV === 'production') {
-    return 'https://new-capstone.onrender.com/api';
-  }
-  
+
   // Development fallback
-  return 'http://localhost:5000/api';
+  return process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 };
 
 const api = axios.create({


### PR DESCRIPTION
## Summary
- Enforce `REACT_APP_API_URL` for production in client API service
- Document `REACT_APP_API_URL` in README environment variables

## Testing
- `npm test`
- `npm run build` *(fails: Internal Error: this package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `npm run install-client` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899924b9ebc832bbc025ef0b5765328