### PR TITLE
refactor: streamline render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,15 +206,15 @@ curl http://localhost:5000/api/images/health
 
 ### Backend
 - Auto-deploy from GitHub `main`
-- Build Command: `npm install`
-- Start Command: `npm start`
+- Build Command: `yarn install`
+- Start Command: `yarn start`
 - Set environment variables manually
 
 ### Frontend
 - Render Static Site
 - Root: `client`
-- Build Command: `npm install && npm run build`
-- Publish directory: `client/build`
+- Build Command: `yarn install && yarn build`
+- Publish directory: `build`
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "install-server": "cd server && yarn install",
     "install-client": "cd client && yarn install",
     "install-all": "yarn install-server && yarn install-client",
-    "render-postbuild": "yarn install-all && yarn build",
+    "render-postbuild": "yarn install-server",
     "clean": "rm -rf node_modules server/node_modules client/node_modules yarn.lock",
     "test": "echo \"No tests yet\" && exit 0"
   },


### PR DESCRIPTION
## Summary
- simplify `render-postbuild` to install only server dependencies
- document Render deployment steps for separate backend and static client builds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689993e95640832bbb13ee2857822ad2