### PR TITLE
chore: remove unused crypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "bcryptjs": "^2.4.3",
     "compression": "^1.8.0",
     "cors": "^2.8.5",
-    "crypto": "^1.0.1",
     "dotenv": "^16.6.1",
     "express": "^4.21.2",
     "express-rate-limit": "^7.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,11 +417,6 @@ cors@^2.8.5:
     object-assign "^4"
     vary "^1"
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
## Summary
- remove unused `crypto` dependency
- regenerate lockfile without `crypto`

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn test` *(fails: package doesn't seem to be present in lockfile)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899a36d6f3c832ba516c91d9c9a1942