### PR TITLE
refactor: use useAuth hook in Navbar

### DIFF
--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -1,13 +1,13 @@
 // client/src/components/Navbar.js - CLEANED UP TOAST IMPORTS
-import React, { useState, useContext } from 'react';
+import React, { useState } from 'react';
 import { Navbar, Nav, Container, Button, NavDropdown } from 'react-bootstrap';
 import { Link, useNavigate } from 'react-router-dom';
-import AuthContext from '../contexts/AuthContext';
+import { useAuth } from '../contexts/AuthContext';
 import './Navbar.css';
 
 const AppNavbar = () => {
   const [expanded, setExpanded] = useState(false);
-  const { user, logout } = useContext(AuthContext);
+  const { user, logout } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = () => {


### PR DESCRIPTION
## Summary
- replace AuthContext use with useAuth hook
- remove unused useContext import in Navbar

## Testing
- `npm test`
- `npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6899b8523484832ba752d5d208dc5897