### PR TITLE
Use API to list GCS product images

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -68,7 +68,7 @@ const Home = () => {
     try {
       console.log('🖼️ Fetching product images...');
       const response = await api.get(
-        `/gcs/buckets/furbabies-petstore/images?prefix=${bucketFolders.PRODUCT}/&public=true`
+        `/images/gcs?prefix=${bucketFolders.PRODUCT}/&public=true`
       );
 
       if (response.data && response.data.success) {

--- a/server/routes/images.js
+++ b/server/routes/images.js
@@ -34,12 +34,43 @@ router.use((req, res, next) => {
 
 // ===== HEALTH CHECK =====
 router.get('/health', (req, res) => {
-  res.json({ 
-    status: 'ok', 
+  res.json({
+    status: 'ok',
     service: 'image-proxy',
     bucket: bucketName,
     timestamp: new Date().toISOString()
   });
+});
+
+// ===== LIST IMAGES IN BUCKET =====
+// Example: GET /api/images/gcs?prefix=product/&public=true
+router.get('/gcs', async (req, res) => {
+  try {
+    const { prefix = '' } = req.query;
+    console.log(`\uD83D\uDCF8 Listing images with prefix: "${prefix}"`);
+
+    const [files] = await bucket.getFiles({ prefix });
+
+    const images = files.map(file => ({
+      name: file.name,
+      fileName: file.name.split('/').pop(),
+      folder: file.name.split('/')[0],
+      contentType: file.metadata?.contentType,
+      size: file.metadata?.size,
+      updated: file.metadata?.updated,
+      created: file.metadata?.timeCreated,
+      publicUrl: `https://storage.googleapis.com/${bucketName}/${file.name}`
+    }));
+
+    res.json({ success: true, data: images });
+  } catch (error) {
+    console.error('\u274C Error listing images:', error);
+    res.status(500).json({
+      success: false,
+      message: 'Failed to list images',
+      error: error.message
+    });
+  }
 });
 
 // ===== MAIN IMAGE SERVING ROUTE =====


### PR DESCRIPTION
## Summary
- serve a list of GCS images via new `/api/images/gcs` endpoint
- fetch product images from the new API instead of direct bucket URL

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899bd9ee328832ba1cbe95a84cbc35a