### PR TITLE
Encode object names for Google Cloud Storage URLs

### DIFF
--- a/client/src/components/SafeImage.js
+++ b/client/src/components/SafeImage.js
@@ -111,16 +111,16 @@ const SafeImage = ({
     // ✅ NEW: Multiple URL strategies based on attempt
     if (attempt === 0 || !useProxy) {
       // First attempt: Direct GCS URL
-      const gcsUrl = `https://storage.googleapis.com/furbabies-petstore/${cleanPath}`;
+      const gcsUrl = `https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(cleanPath)}`;
       console.log(`🖼️ SafeImage - Building GCS URL (attempt ${attempt}): "${imagePath}" -> "${gcsUrl}"`);
       return gcsUrl;
     } else {
       // Second attempt: Proxy URL (if available)
-      const proxyBaseUrl = process.env.NODE_ENV === 'production' 
-        ? process.env.REACT_APP_API_URL?.replace('/api', '') + '/api/images/gcs' 
+      const proxyBaseUrl = process.env.NODE_ENV === 'production'
+        ? process.env.REACT_APP_API_URL?.replace('/api', '') + '/api/images/gcs'
         : 'http://localhost:5000/api/images/gcs';
-      
-      const proxyUrl = `${proxyBaseUrl}/${cleanPath}`;
+
+      const proxyUrl = `${proxyBaseUrl}/${encodeURIComponent(cleanPath)}`;
       console.log(`🖼️ SafeImage - Building Proxy URL (attempt ${attempt}): "${imagePath}" -> "${proxyUrl}"`);
       return proxyUrl;
     }

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -109,7 +109,7 @@ const Home = () => {
     }
 
     const imagePath = findProductImage(product);
-    return `https://storage.googleapis.com/furbabies-petstore/${imagePath}`;
+    return `https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(imagePath)}`;
   };
 
   const testimonials = [

--- a/client/src/pages/Profile.js
+++ b/client/src/pages/Profile.js
@@ -116,7 +116,7 @@ const Profile = () => {
                         <div style={{ height: '200px', overflow: 'hidden' }}>
                           <Card.Img
                             variant="top"
-                            src={`https://storage.googleapis.com/furbabies-petstore/${pet.image}`}
+                            src={`https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(pet.image)}`}
                             alt={pet.name}
                             style={{ 
                               height: '100%', 

--- a/client/src/utils/bucketUtils.js
+++ b/client/src/utils/bucketUtils.js
@@ -17,7 +17,7 @@ export const bucketFolders = {
  * @returns {string} Public URL
  */
 export const getPublicImageUrl = (fileName) => {
-  return `${BUCKET_BASE_URL}/${fileName}`;
+  return `${BUCKET_BASE_URL}/${encodeURIComponent(fileName)}`;
 };
 
 /**

--- a/client/src/utils/imageUtils.js
+++ b/client/src/utils/imageUtils.js
@@ -76,8 +76,8 @@ export const getImageUrl = (imagePath, category = null, type = null) => {
     return getFallbackImage(category, type);
   }
 
-  // Build direct GCS URL
-  const gcsUrl = `${GCS_BASE_URL}/${cleanPath}`;
+  // Build direct GCS URL with encoded path
+  const gcsUrl = `${GCS_BASE_URL}/${encodeURIComponent(cleanPath)}`;
   
   console.log('🖼️ Building image URL:', {
     input: imagePath,
@@ -149,7 +149,7 @@ export const getProxyImageUrl = (imagePath, category = null, type = null) => {
     return getFallbackImage(category, type);
   }
 
-  const proxyUrl = `${getProxyBaseUrl()}/${cleanPath}`;
+  const proxyUrl = `${getProxyBaseUrl()}/${encodeURIComponent(cleanPath)}`;
   
   console.log('🛡️ Building proxy URL:', {
     input: imagePath,

--- a/server/controllers/petController.js
+++ b/server/controllers/petController.js
@@ -20,7 +20,7 @@ const enrichPetData = (pet) => {
   return {
     ...petObj,
     imageUrl: petObj.image ?
-      `https://storage.googleapis.com/furbabies-petstore/${petObj.image}` : null,
+      `https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(petObj.image)}` : null,
     hasImage: !!petObj.image,
     displayName: petObj.name || 'Unnamed Pet',
     isAvailable: petObj.status === 'available',

--- a/server/models/Article.js
+++ b/server/models/Article.js
@@ -249,8 +249,8 @@ articleSchema.virtual('imageUrl').get(function() {
     return this.image;
   }
   
-  // Construct Google Cloud Storage URL
-  return `https://storage.googleapis.com/furbabies-petstore/${this.image}`;
+  // Construct Google Cloud Storage URL with encoded object name
+  return `https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(this.image)}`;
 });
 
 // Virtual for reading statistics

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -541,7 +541,7 @@ router.get(
     const enhancedProducts = products.map((product) => ({
       ...product,
       imageUrl: product.image
-        ? `https://storage.googleapis.com/furbabies-petstore/${product.image}`
+        ? `https://storage.googleapis.com/furbabies-petstore/${encodeURIComponent(product.image)}`
         : null,
       fallbackImageUrl: "/api/images/fallback/product",
       priceFormatted: `$${product.price.toFixed(2)}`,


### PR DESCRIPTION
## Summary
- URL-encode object keys before building Google Cloud Storage links across server and client
- Apply same encoding for proxy links to ensure safe routing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899bda124d8832b98d971387f39cca8