### PR TITLE
Guard against missing GCS bucket and document env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,20 +209,14 @@ curl http://localhost:5000/api/images/health
 - Build Command: `yarn install`
 - Start Command: `yarn start`
 - Set environment variables manually
-<<<<<<< HEAD
+  Required: `MONGODB_URI`, `JWT_SECRET`, `GCS_BUCKET`
+  Optional: `GOOGLE_CLOUD_PROJECT_ID`, `FRONTEND_URL`
 
-=======
-
->>>>>>> 7147bbd10087f3d8c934a448e0fc622cfd9f09f1
 ### Frontend
 - Render Static Site
 - Root: `client`
 - Build Command: `yarn install && yarn build`
-<<<<<<< HEAD
 - Publish directory: `client/build`
-=======
-- Publish directory: `build`
->>>>>>> 7147bbd10087f3d8c934a448e0fc622cfd9f09f1
 
 ---
 

--- a/server/README.md
+++ b/server/README.md
@@ -10,13 +10,13 @@ This document outlines the environment variables required by the backend server 
 |----------|-------------|
 | `MONGODB_URI` | MongoDB connection string. |
 | `JWT_SECRET` | Secret key used to sign JSON Web Tokens. |
+| `GCS_BUCKET` | Name of the Google Cloud Storage bucket for pet images. |
 
 ### Optional
 
 | Variable | Description |
 |----------|-------------|
 | `GOOGLE_CLOUD_PROJECT_ID` | Google Cloud project identifier used for accessing Google Cloud Storage. |
-| `GCS_BUCKET` | Name of the Google Cloud Storage bucket for pet images. |
 | `FRONTEND_URL` | URL of the frontend application used for CORS checks. |
 
 ## Configure on Render

--- a/server/routes/images.js
+++ b/server/routes/images.js
@@ -12,7 +12,9 @@ const storage = new Storage({
 // different buckets without code changes
 const bucketName = process.env.GCS_BUCKET;
 if (!bucketName) {
-  console.warn('GCS_BUCKET environment variable is not set');
+  const message = 'GCS_BUCKET environment variable is not set';
+  console.warn(message);
+  throw new Error(message);
 }
 const bucket = storage.bucket(bucketName);
 


### PR DESCRIPTION
## Summary
- crash server startup when `GCS_BUCKET` is unset to avoid undefined image bucket usage
- note `GCS_BUCKET` as a required environment variable in deployment docs

## Testing
- `cd server && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6899bda19aac832bae547bff23e88a93