### PR TITLE
Handle alternative pet image field

### DIFF
--- a/client/src/components/PetCard.js
+++ b/client/src/components/PetCard.js
@@ -9,8 +9,9 @@ const PetCard = ({ pet }) => {
   const [containerType, setContainerType] = useState('square');
   const [imageLoaded, setImageLoaded] = useState(false);
   
-  const imageSrc = normalizeImageUrl(pet?.image) || 
-                   'https://images.unsplash.com/photo-1601758228041-f3b2795255f1?w=300&h=200&fit=crop&q=80';
+  const imageSrc =
+    normalizeImageUrl(pet?.image || pet?.imageUrl) ||
+    'https://images.unsplash.com/photo-1601758228041-f3b2795255f1?w=300&h=200&fit=crop&q=80';
 
   const handleImageLoad = (e) => {
     const img = e.target;


### PR DESCRIPTION
## Summary
- fall back to `imageUrl` when the main `image` property is absent so pet images render correctly

## Testing
- `CI=true npm --prefix client test -- --watchAll=false --passWithNoTests`
- `npm --prefix client run build` *(fails: Can't resolve 'util' in @google-cloud/storage)*

------
https://chatgpt.com/codex/tasks/task_e_689c57680898832bad71fe484d2361cf