### PR TITLE
feat: enhance SafeImage for product images

### DIFF
--- a/client/src/components/ProductCard.js
+++ b/client/src/components/ProductCard.js
@@ -9,13 +9,8 @@ const ProductCard = ({ product, showAddToCart = true, className }) => {
     <Card className={className || ''}>
       <div style={{ height: 220, overflow: 'hidden' }}>
         <SafeImage
-          // products JSON has product.image = "product/<filename>"
-          item={product}
           src={product.image || product.imagePath || product.imageUrl}
           entityType="product"
-          category={product.category}
-          alt={`${product.name || 'Product'} image`}
-          imgProps={{ style: { objectFit: 'cover', width: '100%', height: '100%' } }}
         />
       </div>
       <Card.Body>


### PR DESCRIPTION
## Summary
- extend SafeImage to resolve pet or product images and show optional loader
- simplify ProductCard usage by passing only image source and entity type

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689f3ae46650832bb60aea80db79401e