### PR TITLE
refactor: use bucket image helpers

### DIFF
--- a/client/src/pages/Browse.js
+++ b/client/src/pages/Browse.js
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import usePetFilters from '../hooks/usePetFilters'; // Fixed: Default import
 import SafeImage from '../components/SafeImage';
-import { getOptimizedImageUrl } from '../utils/imageUtils';
+import { buildPetImageUrl } from '../utils/imageUtils';
 import './Browse.css';
 
 const Browse = () => {
@@ -351,7 +351,7 @@ const Browse = () => {
 
 // Pet Card Component (Grid View)
 const PetCard = ({ pet }) => {
-  const imageUrl = getOptimizedImageUrl(pet.image, { width: 300, height: 300 });
+  const imageUrl = buildPetImageUrl(pet.image, { width: 300, height: 300 });
   
   return (
     <div className="pet-card">
@@ -423,7 +423,7 @@ const PetCard = ({ pet }) => {
 
 // Pet List Item Component (List View)
 const PetListItem = ({ pet }) => {
-  const imageUrl = getOptimizedImageUrl(pet.image, { width: 120, height: 120 });
+  const imageUrl = buildPetImageUrl(pet.image, { width: 120, height: 120 });
   
   return (
     <div className="pet-list-item">

--- a/client/src/pages/Supplies.js
+++ b/client/src/pages/Supplies.js
@@ -1,6 +1,7 @@
 // pages/Supplies.js
 import React, { useState, useEffect } from "react";
 import LoadingSpinner from "../components/admin/LoadingSpinner";
+import SafeImage from "../components/SafeImage";
 
 const Supplies = () => {
   const [supplies, setSupplies] = useState([]);
@@ -85,14 +86,12 @@ const Supplies = () => {
             key={supply.id}
             className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
           >
-            <img
+            <SafeImage
               src={supply.image}
               alt={supply.name}
-              className="w-full h-48 object-cover"
-              onError={(e) => {
-                e.target.src =
-                  "https://via.placeholder.com/300x200?text=Pet+Supply";
-              }}
+              className="w-full h-48"
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              fallback="https://via.placeholder.com/300x200?text=Pet+Supply"
             />
             <div className="p-4">
               <h3 className="text-lg font-semibold text-gray-900 mb-2">


### PR DESCRIPTION
## Summary
- build pet images with `buildPetImageUrl` in Browse cards and list items
- render supply images through `SafeImage` for consistent bucket URL handling

## Testing
- `npm test` *(fails: Missing script "test" at repository root)*
- `npm test --prefix client -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689f3ae51960832b8b641a006dbb34b1