### PR TITLE
chore: enable react-router future flags

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -95,7 +95,7 @@ function App() {
       <AuthProvider>
         <ToastProvider>
           <CartProvider>
-            <Router>
+            <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
               <ScrollToTop />
               <div className="App d-flex flex-column min-vh-100">
                 {/* Navigation */}


### PR DESCRIPTION
## Summary
- enable React Router v7 future flags in App router

## Testing
- `CI=true npm test -- --passWithNoTests`
- `npm start` *(shows only React hook lint warnings, no React Router future-flag warnings)*

------
https://chatgpt.com/codex/tasks/task_e_689fcb428194832b9c3e0b9c0eddf76a